### PR TITLE
Remove spor

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -32,20 +32,20 @@ Alias: $example-org = http://example.org
 Alias: $snomed = http://snomed.info/sct
 // SPOR Code systems (lists)
 	
-Alias: $spor-precautionsForStorage-cs  = https://spor.ema.europa.eu/lists/100000073344
-Alias: $spor-medicinalProducttype-cs  = https://spor.ema.europa.eu/lists/200000025915
-Alias: $spor-organisationRoleType-cs = https://spor.ema.europa.eu/lists/220000000031
-Alias: $spor-combinedPharmaceuticalDoseForm-cs = https://spor.ema.europa.eu/lists/200000000006 
-Alias: $spor-route-cs = https://spor.ema.europa.eu/lists/100000073345 // Routes and Methods of Administration
-Alias: $spor-legalStatusForSupply-cs = https://spor.ema.europa.eu/lists/100000072051	// Legal Status for the Supply
-Alias: $spor-additionalMonitoringIndicator-cs = http://example.org // TO BE FIXED
-Alias: $spor-packType-cs = http://example.org // TO BE FIXED
-Alias: $spor-operationType-cs  = http://example.org // TO BE FIXED
-Alias: $spor-pediatricUseIndicator-cs = http://example.org // TO BE FIXED
-Alias: $spor-marketingStatus-cs = https://spor.ema.europa.eu/lists/100000072052
-Alias: $spor-productNamePartType-cs = https://spor.ema.europa.eu/lists/220000000000 // Medicinal Product Name Part Type
-Alias: $spor-regulatoryEntitlementType-cs = https://spor.ema.europa.eu/lists/220000000060
-Alias: $spor-regulatoryEntitlementStatus-cs = https://spor.ema.europa.eu/lists/100000072049
+//Alias: $spor-precautionsForStorage-cs  = https://spor.ema.europa.eu/lists/100000073344
+//Alias: $spor-medicinalProducttype-cs  = https://spor.ema.europa.eu/lists/200000025915
+//Alias: $spor-organisationRoleType-cs = https://spor.ema.europa.eu/lists/220000000031
+//Alias: $spor-combinedPharmaceuticalDoseForm-cs = https://spor.ema.europa.eu/lists/200000000006 
+//Alias: $spor-route-cs = https://spor.ema.europa.eu/lists/100000073345 // Routes and Methods of Administration
+//Alias: $spor-legalStatusForSupply-cs = https://spor.ema.europa.eu/lists/100000072051	// Legal Status for the Supply
+//Alias: $spor-additionalMonitoringIndicator-cs = http://example.org // TO BE FIXED
+//Alias: $spor-packType-cs = http://example.org // TO BE FIXED
+//Alias: $spor-operationType-cs  = http://example.org // TO BE FIXED
+//Alias: $spor-pediatricUseIndicator-cs = http://example.org // TO BE FIXED
+//Alias: $spor-marketingStatus-cs = https://spor.ema.europa.eu/lists/100000072052
+//Alias: $spor-productNamePartType-cs = https://spor.ema.europa.eu/lists/220000000000 // Medicinal Product Name Part Type
+//Alias: $spor-regulatoryEntitlementType-cs = https://spor.ema.europa.eu/lists/220000000060
+//Alias: $spor-regulatoryEntitlementStatus-cs = https://spor.ema.europa.eu/lists/100000072049
 
 
 Alias: $edqm = http://standardterms.edqm.eu

--- a/input/fsh/examples/drugx/composition75-en.fsh
+++ b/input/fsh/examples/drugx/composition75-en.fsh
@@ -10,7 +10,7 @@ Usage: #example
 
 * status = #final
 
-* type = https://spor.ema.europa.eu/rmswi#100000155538
+* type = $spor-rms#100000155538
 * type.text = "Package Leaflet"
 
 * subject = Reference(DrugX75mgblisterx28) //reference to the medicinal product
@@ -25,12 +25,12 @@ Usage: #example
 
 * section[+].
   * title = "B. Package Leaflet"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "B. PACKAGE LEAFLET"
         
 * section[=].section[+]
   * title = "Package leaflet: Information for the user"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "Package leaflet: Information for the user"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -47,7 +47,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "What is in this leaflet"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "What is in this leaflet"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -63,7 +63,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "1. What DrugX is and what it is used for"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "1. What DrugX is and what it is used for"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -74,7 +74,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "2. What you need to know before you take DrugX"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "2. What you need to know before you take DrugX"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -83,7 +83,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "3. How to take DrugX"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "3. How to take DrugX"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -92,7 +92,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "4. Possible side effects"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "4. Possible side effects"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -101,7 +101,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "5. How to store DrugX"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "5. How to store DrugX"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 
@@ -110,7 +110,7 @@ Usage: #example
         
 * section[=].section[+]
   * title = "6. Contents of the pack and other information"
-  * code = https://spor.ema.europa.eu/rmswi#100000155538
+  * code = $spor-rms#100000155538
   * code.text = "6. Contents of the pack and other information"
   * text.status = #additional
   * text.div = """<div xmlns='http://www.w3.org/1999/xhtml'> 

--- a/input/fsh/terminology/codeSystems.fsh
+++ b/input/fsh/terminology/codeSystems.fsh
@@ -8,3 +8,29 @@ Coded concepts defined for ePI use only."""
 * #flavor "Flavor" "Placeholder for the Flavor concept"
 * #surfaceform "Surface form" "Placeholder for the Surface form concept"
 
+CodeSystem: Spor
+Id: spor
+Title: "Code System example for spor.ema.europa.eu-rmswi"
+Description: """Code system to allow for example use of spor.ema.europa.eu-rmswi in this IG.
+Coded concepts defined for ePI use only."""
+* ^experimental = true
+* ^caseSensitive = false
+* ^url = "https://spor.ema.europa.eu/rmswi"
+* #100000073619
+* #100000072082
+* #200000003222 "PolyVinyl Chloride"
+* #100000155527
+* #100000073496 "Blister"
+* #00000072072
+* #100000072062 "Marketing Authorisation"
+* #220000000034 "Marketing authorisation holder"
+* #100000155538 "PACKAGE LEAFLET"
+* #220000000001
+* #220000000002
+* #220000000003
+* #220000000004
+* #220000000005
+* #100000072084
+* #200000002152
+* #100000109093
+//Alias: $spor-rms = https://spor.ema.europa.eu/rmswi

--- a/input/fsh/terminology/valueSets.fsh
+++ b/input/fsh/terminology/valueSets.fsh
@@ -1,10 +1,11 @@
 //=========================
-ValueSet: VsCombinedDoseForm
-Id: PharmaceuticalDoseForm
-Title: "Combined Pharmaceutical Dose Form"
-Description: "Combined Pharmaceutical Dose Form"
-* ^experimental = false
-* codes from system $spor-combinedPharmaceuticalDoseForm-cs
+// not used in IG
+//ValueSet: VsCombinedDoseForm
+//Id: PharmaceuticalDoseForm
+//Title: "Combined Pharmaceutical Dose Form"
+//Description: "Combined Pharmaceutical Dose Form"
+//* ^experimental = false
+//* codes from system $spor-combinedPharmaceuticalDoseForm-cs
 
 //=========================
 ValueSet: VsAdministrableDoseForm
@@ -19,8 +20,9 @@ ValueSet: VsRouteOfAdministration
 Id: routeOfAdministration
 Title: "Route Of Administration"
 Description:  "Route Of Administration"
-* ^experimental = false
-* codes from system $spor-route-cs
+* ^status = #draft
+* ^experimental = true
+* $spor-rms#100000073619
 
 //==========================
 ValueSet: VsUnitofMeasure

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -2,33 +2,15 @@
 
 # external value sets/codesystems. Code systems are external codesystems not supported by the HL7 Terminology server. HTA request is being made. Implementers have been advised, in the IG, that external codesystems/valuesets are under development during ballot.
 
-Code System URI 'https://spor.ema.europa.eu/rmswi/200000000006' is unknown so the code cannot be validated
-Code System URI 'https://spor.ema.europa.eu/rmswi/100000073345' is unknown so the code cannot be validated
-Code System URI 'https://spor.ema.europa.eu/rmswi' is unknown so the code cannot be validated
 Code System URI 'http://terminology.hl7.org/CodeSystem/mdr' is unknown so the code cannot be validated
 Code System URI 'https://gsrs.ncats.nih.gov/ginas/app/beta/' is unknown so the code cannot be validated
-Code System URI 'https://spor.ema.europa.eu/rmswi/220000000000' is unknown so the code cannot be validated
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/200000000006
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/pmswi
+
 Error from server: Unable to provide support for code system http://example.org
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/100000072052
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/100000072051
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/200000025915
 Error from server: Unable to provide support for code system http://terminology.hl7.org/CodeSystem/mdr
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/220000000031
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/omswi
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/220000000000
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/100000073345
-Error from server: Unable to provide support for code system https://spor.ema.europa.eu/rmswi/100000073344
 Error from server: Unable to provide support for code system https://gsrs.ncats.nih.gov/ginas/app/beta
-[Unable to determine whether the provided codes are in the value set http://hl7.org/fhir/uv/emedicinal-product-info/ValueSet/PharmaceuticalDoseForm because the value set or a code system it depends on is not known to the validator, Code System URI 'https://spor.ema.europa.eu/rmswi/200000000006' is unknown so the code cannot be validated]
-[Unable to determine whether the provided codes are in the value set http://hl7.org/fhir/uv/emedicinal-product-info/ValueSet/routeOfAdministration because the value set or a code system it depends on is not known to the validator, Code System URI 'https://spor.ema.europa.eu/rmswi/100000073345' is unknown so the code cannot be validated]
-[Code System URI 'https://spor.ema.europa.eu/rmswi' is unknown so the code cannot be validated]
-The code 100000155538 is not valid in the system https://spor.ema.europa.eu/rmswi
+
 The code sectionCode is not valid in the system http://example.org
 WARNING: ValueSet/sectionCode: ValueSet.compose[0].include[0]: Unknown System 'http://example.org' specified, so Concepts and Filters can't be checked (Details: Local Error: Unable to resolve system http://example.org. Server Error: The code system 'http://example.org' is not known (encountered paired with code = 'sectionCode'); The code provided (http://example.org#sectionCode) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4))
-WARNING: ValueSet/epiType: ValueSet.compose[0].include[0]: Unknown System 'https://spor.ema.europa.eu/rmswi' specified, so Concepts and Filters can't be checked (Details: Local Error: Unable to resolve system https://spor.ema.europa.eu/rmswi. Server Error: The code system 'https://spor.ema.europa.eu/rmswi' is not known (encountered paired with code = '100000155538'); The code provided (https://spor.ema.europa.eu/rmswi#100000155538) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4))
 
 # In EU is a reserved code is ISO 3166 "Extended for any application needing to represent the name European Union in August 1999, the current HTA server does not support it. HTA request is being made.
  The code EU is not valid in the system urn:iso:std:iso:3166

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -51,3 +51,4 @@ menu:
 
 parameters:
   jira-code: uv-emedicinal-product-info
+  special-url: https://spor.ema.europa.eu/rmswi


### PR DESCRIPTION
I made two commits
One to create an Experimental example code system to house examples codes, and add the special-url parameter for the url of that code system to keep it from causing any warnings or errors.

Second commit was to remove SPOR relevant warnings and errors as these no longer occur.