### PR TITLE
Fix entry index in bundle-drugx-epiType1.fsh

### DIFF
--- a/input/fsh/examples/drugx/bundle-drugx-epiType1.fsh
+++ b/input/fsh/examples/drugx/bundle-drugx-epiType1.fsh
@@ -17,8 +17,8 @@ Description: "Example of a type 1 ePI Bundle - Package Insert"
 * timestamp = "2018-06-23T08:38:00+02:00"
 
 // Composition
-* entry[composition].fullUrl = "urn:uuid:5467a2fd-2463-4ec7-a6bb-b7322000f867"
-* entry[composition].resource = compositionDrugX75type1
+* entry[+].fullUrl = "urn:uuid:5467a2fd-2463-4ec7-a6bb-b7322000f867"
+* entry[=].resource = compositionDrugX75type1
 
 // Organization
 * entry[+].fullUrl = "urn:uuid:d71bf884-90eb-47f9-81b7-fa81ecec7e75"


### PR DESCRIPTION
This fixes the build error that is caused by the Organization being the first entry in the example Bundle.